### PR TITLE
Fix bug in V_bound call due to new ROI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
     - libglpk-dev
 
 r_github_packages:
-  - dirkschumacher/ompr
   - hadley/testthat
   - jimhester/covr
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: ompr.roi
 Type: Package
 Title: A Solver for 'ompr' that Uses the R Optimization Infrastructure ('ROI')
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: person("Dirk", "Schumacher", email = "mail@dirk-schumacher.net",
-            role = c("aut", "cre", "cph"))
+            role = c("aut", "cre"))
 Description: A solver for 'ompr' based on the R Optimization Infrastructure ('ROI').
   The package makes all solvers in 'ROI' available to solve 'ompr' models. Please see the
   'ompr' website <https://dirkschumacher.github.io/ompr> and package docs for more information

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ompr.roi 0.6.1
+
+## Bugfix
+
+* Fixed a bug where the `ROI::V_bound` object was incorrectly initialised. This causes an error with `ROI` >= 0.3.0.
+
 # ompr.roi 0.6.0
 
 * First release on CRAN

--- a/R/with-roi.R
+++ b/R/with-roi.R
@@ -72,8 +72,8 @@ with_ROI <- function(solver, ...) {
     # remove those lbs that are 0
     # and those ubs that are Inf
     # otherwise ROI throws a warnning
-    li <- seq_len(length(column_bounds_l))
-    ui <- seq_len(length(column_bounds_u))
+    li <- seq_along(column_bounds_l)
+    ui <- seq_along(column_bounds_u)
     lb <- column_bounds_l
     ub <- column_bounds_u
     if (length(li) > 0) {
@@ -92,7 +92,7 @@ with_ROI <- function(solver, ...) {
         ui = ui,
         lb = lb,
         ub = ub,
-        nobj = max(li, ui)
+        nobj = length(obj_fun)
       )
     } else {
       bounds <- NULL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,7 @@ environment:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github dirkschumacher/ompr
-  
+
 test_script:
   - travis-tool.sh run_tests
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,19 +1,17 @@
-## Resubmission
-This is a resubmission. In this version I have:
+## Submission 0.6.1
 
-* Removed the LICENSE file to not repeat the content of the GPL.
+* Fixed an error caused by a new version of `ROI`. No other changes were made.
   
 ## Test environments
-* local OS X install, R 3.3.3
+* local OS X install, R 3.4.2
 * ubuntu 12.04 (on travis-ci), R release, oldrel, devel
-* Windows Server 2012 R2 x64 (on appveyor), R release, oldrel, devel
+* Windows Server 2012 R2 x64 (on appveyor), R release, oldrel
+* Windows Server 2008 (64-bit) (on win-builder), R-devel, R-release
 
 ## R CMD check results
 
 0 errors | 0 warnings | 0 notes
 
-* This is a new release.
-
 ## Reverse dependencies
 
-This is a new release, so there are no reverse dependencies.
+There are no reverse dependencies.


### PR DESCRIPTION
The call to V_bound was not correct before and the new ROI version now actively prevents that. Also some minor other changes.

This PR is not intended to be merged. 